### PR TITLE
Custom hostname (SSL for SaaS) support

### DIFF
--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -112,6 +112,7 @@ func Provider() terraform.ResourceProvider {
 			"cloudflare_argo":                        resourceCloudflareArgo(),
 			"cloudflare_byo_ip_prefix":               resourceCloudflareBYOIPPrefix(),
 			"cloudflare_custom_pages":                resourceCloudflareCustomPages(),
+			"cloudflare_custom_hostname":             resourceCloudflareCustomHostname(),
 			"cloudflare_custom_ssl":                  resourceCloudflareCustomSsl(),
 			"cloudflare_filter":                      resourceCloudflareFilter(),
 			"cloudflare_firewall_rule":               resourceCloudflareFirewallRule(),

--- a/cloudflare/resource_cloudflare_custom_hostname.go
+++ b/cloudflare/resource_cloudflare_custom_hostname.go
@@ -2,6 +2,7 @@ package cloudflare
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func resourceCloudflareCustomHostname() *schema.Resource {
@@ -17,12 +18,13 @@ func resourceCloudflareCustomHostname() *schema.Resource {
 		SchemaVersion: 0,
 		Schema: map[string]*schema.Schema{
 			"hostname": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(0, 255),
 			},
 			"custom_origin_servver": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"ssl": {
 				Type:     schema.TypeList,
@@ -37,12 +39,14 @@ func resourceCloudflareCustomHostname() *schema.Resource {
 							Optional: true,
 						},
 						"method": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"http", "txt", "email"}, false),
 						},
 						"type": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"dv"}, false),
 						},
 						"cname_target": {
 							Type:     schema.TypeString,
@@ -73,16 +77,19 @@ func resourceCloudflareCustomHostname() *schema.Resource {
 								SchemaVersion: 1,
 								Schema: map[string]*schema.Schema{
 									"http2": {
-										Type:     schema.TypeString,
-										Optional: true,
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
 									},
 									"tls13": {
-										Type:     schema.TypeString,
-										Optional: true,
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
 									},
 									"min_tls_version": {
-										Type:     schema.TypeString,
-										Optional: true,
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice([]string{"1.0", "1.1", "1.2", "1.3"}, false),
 									},
 									"ciphers": {
 										Type:     schema.TypeList,

--- a/cloudflare/resource_cloudflare_custom_hostname.go
+++ b/cloudflare/resource_cloudflare_custom_hostname.go
@@ -17,20 +17,23 @@ func resourceCloudflareCustomHostname() *schema.Resource {
 
 		SchemaVersion: 0,
 		Schema: map[string]*schema.Schema{
+			"zone_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
 			"hostname": {
 				Type:         schema.TypeString,
 				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: validation.StringLenBetween(0, 255),
 			},
-			"custom_origin_servver": {
+			"custom_origin_server": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
 			"ssl": {
 				Type:     schema.TypeList,
 				Required: true,
-				MinItems: 1,
-				MaxItems: 1,
 				Elem: &schema.Resource{
 					SchemaVersion: 1,
 					Schema: map[string]*schema.Schema{
@@ -46,6 +49,7 @@ func resourceCloudflareCustomHostname() *schema.Resource {
 						"type": {
 							Type:         schema.TypeString,
 							Optional:     true,
+							Default:      "dv",
 							ValidateFunc: validation.StringInSlice([]string{"dv"}, false),
 						},
 						"certificate_authority": {
@@ -75,9 +79,7 @@ func resourceCloudflareCustomHostname() *schema.Resource {
 						},
 						"settings": {
 							Type:     schema.TypeList,
-							Required: true,
-							MinItems: 1,
-							MaxItems: 1,
+							Optional: true,
 							Elem: &schema.Resource{
 								SchemaVersion: 1,
 								Schema: map[string]*schema.Schema{
@@ -114,10 +116,8 @@ func resourceCloudflareCustomHostname() *schema.Resource {
 				Computed: true,
 			},
 			"ownership_verification": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeMap,
 				Computed: true,
-				MinItems: 1,
-				MaxItems: 1,
 				Elem: &schema.Resource{
 					SchemaVersion: 1,
 					Schema: map[string]*schema.Schema{
@@ -137,10 +137,8 @@ func resourceCloudflareCustomHostname() *schema.Resource {
 				},
 			},
 			"ownership_verification_http": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeMap,
 				Computed: true,
-				MinItems: 1,
-				MaxItems: 1,
 				Elem: &schema.Resource{
 					SchemaVersion: 1,
 					Schema: map[string]*schema.Schema{

--- a/cloudflare/resource_cloudflare_custom_hostname.go
+++ b/cloudflare/resource_cloudflare_custom_hostname.go
@@ -1,0 +1,168 @@
+package cloudflare
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceCloudflareCustomHostname() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCloudflareCustomHostnameCreate,
+		Read:   resourceCloudflareCustomHostnameRead,
+		Update: resourceCloudflareCustomHostnameUpdate,
+		Delete: resourceCloudflareCustomHostnameDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceCloudflareCustomHostnameImport,
+		},
+
+		SchemaVersion: 0,
+		Schema: map[string]*schema.Schema{
+			"hostname": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"custom_origin_servver": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ssl": {
+				Type:     schema.TypeList,
+				Required: true,
+				MinItems: 1,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					SchemaVersion: 1,
+					Schema: map[string]*schema.Schema{
+						"status": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"method": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"cname_target": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"cname_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"wildcard": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"custom_certificate": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"custom_key": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"settings": {
+							Type:     schema.TypeList,
+							Required: true,
+							MinItems: 1,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								SchemaVersion: 1,
+								Schema: map[string]*schema.Schema{
+									"http2": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"tls13": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"min_tls_version": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"ciphers": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ownership_verification": {
+				Type:     schema.TypeList,
+				Computed: true,
+				MinItems: 1,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					SchemaVersion: 1,
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"ownership_verification_http": {
+				Type:     schema.TypeList,
+				Computed: true,
+				MinItems: 1,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					SchemaVersion: 1,
+					Schema: map[string]*schema.Schema{
+						"http_url": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"http_body": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceCloudflareCustomHostnameRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceCloudflareCustomHostnameDelete(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceCloudflareCustomHostnameCreate(d *schema.ResourceData, meta interface{}) error {
+	return resourceCloudflareCustomHostnameRead(d, meta)
+}
+
+func resourceCloudflareCustomHostnameUpdate(d *schema.ResourceData, meta interface{}) error {
+	return resourceCloudflareCustomHostnameRead(d, meta)
+}
+
+func resourceCloudflareCustomHostnameImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	return []*schema.ResourceData{d}, nil
+}

--- a/cloudflare/resource_cloudflare_custom_hostname.go
+++ b/cloudflare/resource_cloudflare_custom_hostname.go
@@ -158,6 +158,42 @@ func resourceCloudflareCustomHostname() *schema.Resource {
 }
 
 func resourceCloudflareCustomHostnameRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*cloudflare.API)
+	zoneID := d.Get("zone_id").(string)
+	hostnameID := d.Id()
+
+	customHostname, err := client.CustomHostname(zoneID, hostnameID)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error reading custom hostname %q", hostnameID))
+	}
+
+	d.Set("ssl.custom_origin_server", customHostname.CustomOriginServer)
+
+	d.Set("ssl.0.type", customHostname.SSL.Type)
+	d.Set("ssl.0.method", customHostname.SSL.Method)
+	d.Set("ssl.0.wildcard", customHostname.SSL.Wildcard)
+	d.Set("ssl.0.status", customHostname.SSL.Status)
+	d.Set("ssl.0.cname_target", customHostname.SSL.CnameTarget)
+	d.Set("ssl.0.cname_name", customHostname.SSL.CnameName)
+	d.Set("ssl.0.custom_certificate", customHostname.SSL.CustomCertificate)
+	d.Set("ssl.0.custom_key", customHostname.SSL.CustomKey)
+
+	d.Set("ssl.0.settings.0.http2", customHostname.SSL.Settings.HTTP2)
+	d.Set("ssl.0.settings.0.tls13", customHostname.SSL.Settings.TLS13)
+	d.Set("ssl.0.settings.0.min_tls_version", customHostname.SSL.Settings.MinTLSVersion)
+	d.Set("ssl.0.settings.0.ciphers", flattenStringList(customHostname.SSL.Settings.Ciphers))
+
+	ownershipVerificationCfg := map[string]interface{}{}
+	ownershipVerificationCfg["type"] = customHostname.OwnershipVerification.Type
+	ownershipVerificationCfg["value"] = customHostname.OwnershipVerification.Value
+	ownershipVerificationCfg["name"] = customHostname.OwnershipVerification.Name
+	d.Set("ownership_verification", ownershipVerificationCfg)
+
+	ownershipVerificationHTTPCfg := map[string]interface{}{}
+	ownershipVerificationHTTPCfg["http_body"] = customHostname.OwnershipVerificationHTTP.HTTPBody
+	ownershipVerificationHTTPCfg["http_url"] = customHostname.OwnershipVerificationHTTP.HTTPUrl
+	d.Set("ownership_verification_http", ownershipVerificationHTTPCfg)
+
 	return nil
 }
 

--- a/cloudflare/resource_cloudflare_custom_hostname.go
+++ b/cloudflare/resource_cloudflare_custom_hostname.go
@@ -48,6 +48,11 @@ func resourceCloudflareCustomHostname() *schema.Resource {
 							Optional:     true,
 							ValidateFunc: validation.StringInSlice([]string{"dv"}, false),
 						},
+						"certificate_authority": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"lets_encrypt", "digicert"}, false),
+						},
 						"cname_target": {
 							Type:     schema.TypeString,
 							Optional: true,

--- a/cloudflare/resource_cloudflare_custom_hostname_test.go
+++ b/cloudflare/resource_cloudflare_custom_hostname_test.go
@@ -1,0 +1,244 @@
+package cloudflare
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccCloudflareCustomHostnameBasic(t *testing.T) {
+	t.Parallel()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	rnd := generateRandomResourceName()
+	resourceName := "cloudflare_custom_hostname." + rnd
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareCustomHostnameBasic(zoneID, rnd, domain),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "zone_id", zoneID),
+					resource.TestCheckResourceAttr(resourceName, "hostname", fmt.Sprintf("%s.%s", rnd, domain)),
+					resource.TestCheckResourceAttr(resourceName, "ssl.0.method", "txt"),
+					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification.value"),
+					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification.type"),
+					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification.name"),
+					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification_http.http_url"),
+					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification_http.http_body"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudflareCustomHostnameBasic(zoneID, rnd, domain string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_custom_hostname" "%[2]s" {
+  zone_id = "%[1]s"
+  hostname = "%[2]s.%[3]s"
+  ssl {
+    method = "txt"
+  }
+}
+`, zoneID, rnd, domain)
+}
+
+func TestAccCloudflareCustomHostnameWithCustomOriginServer(t *testing.T) {
+	t.Parallel()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	rnd := generateRandomResourceName()
+	resourceName := "cloudflare_custom_hostname." + rnd
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareCustomHostnameWithCustomOriginServer(zoneID, rnd, domain),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "zone_id", zoneID),
+					resource.TestCheckResourceAttr(resourceName, "hostname", fmt.Sprintf("%s.%s", rnd, domain)),
+					resource.TestCheckResourceAttr(resourceName, "custom_origin_server", fmt.Sprintf("origin.%s.terraform.cfapi.net", rnd)),
+					resource.TestCheckResourceAttr(resourceName, "ssl.0.method", "txt"),
+					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification.value"),
+					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification.type"),
+					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification.name"),
+					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification_http.http_url"),
+					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification_http.http_body"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudflareCustomHostnameWithCustomOriginServer(zoneID, rnd, domain string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_custom_hostname" "%[2]s" {
+  zone_id = "%[1]s"
+  hostname = "%[2]s.%[3]s"
+  custom_origin_server = "origin.%[2]s.terraform.cfapi.net"
+  ssl {
+    method = "txt"
+  }
+}
+
+resource "cloudflare_record" "%[2]s" {
+  zone_id = "%[1]s"
+  name    = "origin.%[2]s.terraform.cfapi.net"
+  value   = "example.com"
+  type    = "CNAME"
+  ttl     = 3600
+}`, zoneID, rnd, domain)
+}
+
+func TestAccCloudflareCustomHostnameWithHTTPValidation(t *testing.T) {
+	t.Parallel()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	rnd := generateRandomResourceName()
+	resourceName := "cloudflare_custom_hostname." + rnd
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareCustomHostnameWithHTTPValidation(zoneID, rnd, domain),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "zone_id", zoneID),
+					resource.TestCheckResourceAttr(resourceName, "hostname", fmt.Sprintf("%s.%s", rnd, domain)),
+					resource.TestCheckResourceAttr(resourceName, "ssl.0.method", "http"),
+					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification.value"),
+					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification.type"),
+					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification.name"),
+					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification_http.http_url"),
+					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification_http.http_body"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudflareCustomHostnameWithHTTPValidation(zoneID, rnd, domain string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_custom_hostname" "%[2]s" {
+  zone_id = "%[1]s"
+  hostname = "%[2]s.%[3]s"
+  ssl {
+    method = "http"
+  }
+}
+`, zoneID, rnd, domain)
+}
+
+func TestAccCloudflareCustomHostnameWithCustomSSLSettings(t *testing.T) {
+	t.Parallel()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	rnd := generateRandomResourceName()
+	resourceName := "cloudflare_custom_hostname." + rnd
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareCustomHostnameWithCustomSSLSettings(zoneID, rnd, domain),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "zone_id", zoneID),
+					resource.TestCheckResourceAttr(resourceName, "hostname", fmt.Sprintf("%s.%s", rnd, domain)),
+					resource.TestCheckResourceAttr(resourceName, "ssl.0.settings.0.http2", "off"),
+					resource.TestCheckResourceAttr(resourceName, "ssl.0.settings.0.min_tls_version", "1.2"),
+					resource.TestCheckResourceAttr(resourceName, "ssl.0.settings.0.ciphers.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ssl.0.settings.0.ciphers.0", "ECDHE-RSA-AES128-GCM-SHA256"),
+					resource.TestCheckResourceAttr(resourceName, "ssl.0.settings.0.ciphers.1", "AES128-SHA"),
+					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification.value"),
+					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification.type"),
+					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification.name"),
+					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification_http.http_url"),
+					resource.TestCheckResourceAttrSet(resourceName, "ownership_verification_http.http_body"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudflareCustomHostnameWithCustomSSLSettings(zoneID, rnd, domain string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_custom_hostname" "%[2]s" {
+  zone_id = "%[1]s"
+  hostname = "%[2]s.%[3]s"
+  ssl {
+    method = "http"
+    settings {
+      http2 = "off"
+      min_tls_version = "1.2"
+      ciphers = [
+        "ECDHE-RSA-AES128-GCM-SHA256",
+        "AES128-SHA"
+      ]
+    }
+  }
+}
+`, zoneID, rnd, domain)
+}
+
+func TestAccCloudflareCustomHostnameUpdate(t *testing.T) {
+	t.Parallel()
+	zoneID := os.Getenv("CLOUDFLARE_ZONE_ID")
+	domain := os.Getenv("CLOUDFLARE_DOMAIN")
+	rnd := generateRandomResourceName()
+	resourceName := "cloudflare_custom_hostname." + rnd
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudflareCustomHostnameWithCustomSSLSettings(zoneID, rnd, domain),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "zone_id", zoneID),
+					resource.TestCheckResourceAttr(resourceName, "hostname", fmt.Sprintf("%s.%s", rnd, domain)),
+					resource.TestCheckResourceAttr(resourceName, "ssl.0.settings.0.http2", "off"),
+					resource.TestCheckResourceAttr(resourceName, "ssl.0.settings.0.min_tls_version", "1.2"),
+					resource.TestCheckResourceAttr(resourceName, "ssl.0.settings.0.ciphers.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ssl.0.settings.0.ciphers.0", "ECDHE-RSA-AES128-GCM-SHA256"),
+					resource.TestCheckResourceAttr(resourceName, "ssl.0.settings.0.ciphers.1", "AES128-SHA"),
+				),
+			},
+			{
+				Config: testAccCheckCloudflareCustomHostnameWithCustomSSLSettingsUpdated(zoneID, rnd, domain),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "zone_id", zoneID),
+					resource.TestCheckResourceAttr(resourceName, "hostname", fmt.Sprintf("%s.%s", rnd, domain)),
+					resource.TestCheckResourceAttr(resourceName, "ssl.0.settings.0.http2", "off"),
+					resource.TestCheckResourceAttr(resourceName, "ssl.0.settings.0.min_tls_version", "1.1"),
+					resource.TestCheckResourceAttr(resourceName, "ssl.0.settings.0.ciphers.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ssl.0.settings.0.ciphers.0", "ECDHE-RSA-AES128-GCM-SHA256"),
+					resource.TestCheckResourceAttr(resourceName, "ssl.0.settings.0.ciphers.1", "AES128-SHA"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudflareCustomHostnameWithCustomSSLSettingsUpdated(zoneID, rnd, domain string) string {
+	return fmt.Sprintf(`
+resource "cloudflare_custom_hostname" "%[2]s" {
+  zone_id = "%[1]s"
+  hostname = "%[2]s.%[3]s"
+  ssl {
+    method = "http"
+    settings {
+      http2 = "off"
+      min_tls_version = "1.1"
+      ciphers = [
+        "ECDHE-RSA-AES128-GCM-SHA256",
+        "AES128-SHA"
+      ]
+    }
+  }
+}
+`, zoneID, rnd, domain)
+}

--- a/website/cloudflare.erb
+++ b/website/cloudflare.erb
@@ -73,6 +73,9 @@
             <li<%= sidebar_current("docs-cloudflare-resource-custom-pages") %>>
               <a href="/docs/providers/cloudflare/r/custom_pages.html">cloudflare_custom_pages</a>
             </li>
+            <li<%= sidebar_current("docs-cloudflare-resource-custom-hostname") %>>
+              <a href="/docs/providers/cloudflare/r/custom_hostname.html">cloudflare_custom_hostname</a>
+            </li>
             <li<%= sidebar_current("docs-cloudflare-resource-custom-ssl") %>>
               <a href="/docs/providers/cloudflare/r/custom_ssl.html">cloudflare_custom_ssl</a>
             </li>

--- a/website/docs/r/custom_hostname.html.markdown
+++ b/website/docs/r/custom_hostname.html.markdown
@@ -1,0 +1,74 @@
+---
+layout: "cloudflare"
+page_title: "Cloudflare: cloudflare_custom_hostname"
+sidebar_current: "docs-cloudflare-resource-custom-hostname"
+description: !-
+  Provides a Cloudflare custom hostname resource.
+---
+
+# cloudflare_custom_hostname
+
+Provides a Cloudflare custom hostname (also known as SSL for SaaS) resource.
+
+## Example Usage
+
+```hcl
+resource "cloudflare_custom_hostname" "example_hostname" {
+  zone_id  = "d41d8cd98f00b204e9800998ecf8427e"
+  hostname = "hostname.example.com"
+  ssl {
+    method = "txt"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `zone_id` - (Required) The DNS zone ID where the custom hostname should be assigned.
+* `hostname` - (Required) Hostname you intend to request a certificate for.
+* `custom_origin_server` - (Optional) The custom origin server used for certificates.
+* `ssl` - (Required) SSL configuration of the certificate. See further notes below.
+
+**ssl** block supports:
+
+* `method` - (Required) Domain control validation (DCV) method used for this
+  hostname. Valid values are `"txt"`, `"http"` and `"email"`.
+* `type` - (Required) Level of validation to be used for this hostname. Domain validation ("dv") must be used.
+* `wildcard` - (Required) Indicates whether the certificate covers a wildcard.
+* `custom_certificate` - (Optional) If a custom uploaded certificate is used.
+* `custom_key` - (Optional) The key for a custom uploaded certificate.
+* `settings` - (Required) SSL/TLS settings for the certificate. See further notes below.
+
+**settings** block supports:
+
+* `http2` - (Optional) Whether or not HTTP2 should be supported. Valid values are `"on"` or `"off"`.
+* `tls12` - (Optional) Whether or not TLSv1.3 should be supported. Valid values are `"on"` or `"off"`.
+* `min_tls_version` - (Optional) Lowest version of TLS this certificate should
+  support. Valid values are `"1.0"`, `"1.1"`, `"1.2"` and `"1.3"`.
+* `ciphers` - (Optional) List of SSL/TLS ciphers to associate with this certificate.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `ownership_verification.type` - Domain control validation (DCV) method used
+  for the hostname.
+* `ownership_verification.value` - Domain control validation (DCV) value for
+  confirming ownership. Example, "_cf-custom-hostname.example.com`
+* `ownership_verification.name` - Domain control validation (DCV) name
+  confirming ownership. Example, "03f28e11-fa64-4966-bb1e-dd2423e16f36"`
+* `ownership_verification_http.http_url` - Domain control validation (DCV) URL for
+  confirming ownership. Example, `http://hostname.example.com/.well-known/cf-custom-hostname-challenge/643395f9-de80-42f5-a2a0-e03ff60cf2a7`
+* `ownership_verification_http.http_body` - Domain control validation (DCV) body for
+  confirming ownership. Example, `03f28e11-fa64-4966-bb1e-dd2423e16f36`
+
+## Import
+
+Custom hostname certificates can be imported using a composite ID formed of the zone ID and [hostname ID](https://api.cloudflare.com/#custom-hostname-for-a-zone-properties),
+separated by a "/" e.g.
+
+```
+$ terraform import cloudflare_custom_hostname.example d41d8cd98f00b204e9800998ecf8427e/0d89c70d-ad9f-4843-b99f-6cc0252067e9
+```

--- a/website/docs/r/custom_hostname.html.markdown
+++ b/website/docs/r/custom_hostname.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
 **settings** block supports:
 
 * `http2` - (Optional) Whether or not HTTP2 should be supported. Valid values are `"on"` or `"off"`.
-* `tls12` - (Optional) Whether or not TLSv1.3 should be supported. Valid values are `"on"` or `"off"`.
+* `tls13` - (Optional) Whether or not TLSv1.3 should be supported. Valid values are `"on"` or `"off"`.
 * `min_tls_version` - (Optional) Lowest version of TLS this certificate should
   support. Valid values are `"1.0"`, `"1.1"`, `"1.2"` and `"1.3"`.
 * `ciphers` - (Optional) List of SSL/TLS ciphers to associate with this certificate.


### PR DESCRIPTION
Creates the new `cloudflare_custom_hostname` resource that allows management of the SSL for SaaS product.

Documentation: 
- https://api.cloudflare.com/#custom-hostname-for-a-zone-properties
- https://developers.cloudflare.com/ssl/ssl-for-saas

### Screenshots of the documentation site

![](https://shares.jacobbednarz.com/97hn8f2e1g.png)

This PR will be squashed into a single commit before merging.

Closes #336